### PR TITLE
Bugfix/pagination

### DIFF
--- a/src/views/_pagination.html
+++ b/src/views/_pagination.html
@@ -1,19 +1,25 @@
 {% macro pagination(totalPages, currentPage) %}
     <nav class="pagination fs-5">
         <ul class="hstack gap-3">
+            {% if ( totalPages != 1 ) %}
+            {% if ( currentPage != 1 ) %}
             <li class="pagination__prev">
                 <a href="?page={{ currentPage - 1 }}">< Anterior</a>
             </li>
+            {% endif %}
 
             <li>
                 <span class="current" aria-current="page">
                     {{ currentPage }}
                 </span> de {{ totalPages }}
             </li>
-
+            
+            {% if ( currentPage != totalPages ) %}
             <li class="pagination__next">
                 <a href="?page={{ currentPage + 1 }}">Siguiente ></a>
             </li>
+            {% endif %}
+            {% endif %}
         </ul>
     </nav>
 {% endmacro %}

--- a/tests/unit/ui/pagination.spec.js
+++ b/tests/unit/ui/pagination.spec.js
@@ -4,7 +4,7 @@
 
 const utils = require('../../ui-utils.js')
 
-const { getByText } = require('@testing-library/dom');
+const { getByText, queryByText } = require('@testing-library/dom');
 require('@testing-library/jest-dom');
 
 function renderPagination(pagination) {
@@ -84,5 +84,46 @@ describe('Paginación', () => {
 
         expect(prevLink).toBeVisible();
         expect(prevLink.getAttribute('href')).toBe(`?page=${pagination.currentPage - 1}`);
+    });
+
+    test('No debería mostrarse el botón anterior en la primera página', async () => {
+        const pagination = {
+            totalPages: 10,
+            currentPage: 1
+        }
+        const html = renderPagination(pagination);
+
+        document.body.innerHTML = html;
+        const prevLink = queryByText(document.body, '< Anterior');
+
+        expect(prevLink).toBeNull();
+    });
+
+    test('No debería mostrarse el botón siguiente en la última página', async () => {
+        const pagination = {
+            totalPages: 10,
+            currentPage: 10
+        }
+        const html = renderPagination(pagination);
+
+        document.body.innerHTML = html;
+        const nextLink = queryByText(document.body, 'Siguiente >');
+
+        expect(nextLink).toBeNull();
+    });
+
+    test('No deberían mostrarse los botones de paginación si hay una única página', async () => {
+        const pagination = {
+            totalPages: 1,
+            currentPage: 1
+        }
+        const html = renderPagination(pagination);
+
+        document.body.innerHTML = html;
+        const prevLink = queryByText(document.body, '< Anterior');
+        const nextLink = queryByText(document.body, 'Siguiente >');
+
+        expect(prevLink).toBeNull();
+        expect(nextLink).toBeNull();
     });
 });


### PR DESCRIPTION
Arreglé los bugs de la paginación y ahora:
* No aparece el botón Anterior en la primera página.
* No aparece el botón Siguiente en la última pagina.
* No aparecen los botones cuando solo hay una página.